### PR TITLE
make stringification configureable

### DIFF
--- a/MMM-MQTTbridge.js
+++ b/MMM-MQTTbridge.js
@@ -13,6 +13,7 @@
 Module.register("MMM-MQTTbridge", {
   defaults: {
     mqttServer: "mqtt://:@localhost:1883",
+    stringifyPayload: true,
     notiConfig:
     {
       listenNoti: true,
@@ -130,15 +131,29 @@ Module.register("MMM-MQTTbridge", {
               {
                 if (this.config.notiDictionary.notiHook[i].notiPayload[j].notiMqttCmd[k] == this.config.notiDictionary.notiMqttCommands[x].commandId) 
                 {
+                  let curStringifyPayload
+                  if (typeof this.config.notiDictionary.notiMqttCommands[x].stringifyPayload !== "undefined"){
+                    curStringifyPayload = this.config.notiDictionary.notiMqttCommands[x].stringifyPayload
+                  } else {
+                    curStringifyPayload = this.config.stringifyPayload
+                  }
                   // if NOTI matched in the Dictionary, send respective MQTT message
                   // If payloadValue is empty in notiDictionary --> send payload of Notification to MQTT - Otherwise send payload defined in notiDictionary
                   if (this.config.notiDictionary.notiHook[i].notiPayload[j].payloadValue == '') 
                   {
-                    this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, JSON.stringify(payload));
+                    if (curStringifyPayload){
+                      this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, JSON.stringify(payload));
+                    } else {
+                      this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, payload);
+                    }
                   } 
                   else 
                   {
-                    this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, JSON.stringify(this.config.notiDictionary.notiMqttCommands[x].mqttMsgPayload));
+                    if (curStringifyPayload){
+                      this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, JSON.stringify(this.config.notiDictionary.notiMqttCommands[x].mqttMsgPayload));
+                    } else {
+                      this.publishNotiToMqtt(this.config.notiDictionary.notiMqttCommands[x].mqttTopic, this.config.notiDictionary.notiMqttCommands[x].mqttMsgPayload);
+                    }
                   }
                   break;
                 }

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,8 @@ If you like to use a tls encrypted connection to your server you can use this ex
 
 ### GENERAL SECTION
 
+- `stringifyPayload`- specify if the payload of notifications should be converted with "JSON.stringify" before it will be send as MQTT message, default is true. The setting can be overriden for each notification seperatly.
+
 **MQTT part**
 - `mqttServer` - set you server address using the following format:   "mqtt://"+USERNAME+":"+PASSWORD+"@"+IPADDRESS+":"+PORT or "mqtts://"+USERNAME+":"+PASSWORD+"@"+IPADDRESS+":"+PORT. E.g. if you are using your broker with plaintext connnection *without username/password* on *localhost* with port *1883*, you config should looks "*mqtt://:@localhost:1883*",
 - `mqttClientKey`- specify the path of the client tls key file (mandatory if using tls connetion). i.e. "/home/pi/client-key.pem";
@@ -111,7 +113,9 @@ If you like to use a tls encrypted connection to your server you can use this ex
 Should be set within `~/MagicMirror/modules/MMM-MQTTbridge/dict/notiDictionary.js`
 
 If payloadValue is empty, the actual payload of the notification will be used as MQTT payload.
-If payloadValue is specified and matches the payload received via the notification, mqttMsgPayload will be used as MQTT payload. 
+If payloadValue is specified and matches the payload received via the notification, mqttMsgPayload will be used as MQTT payload.
+
+You can configure if the payload of a notification should be stringified before it is send with the optional option "stringifyPayload". The default value is the one configured in the general section.
 
 **Please note, if your Noti issues boolean values (e.g. true/false) - you need to paste into notiDict 1 or 0 for true/false**.
 
@@ -135,6 +139,15 @@ var notiHook = [
       },
     ],
   },
+  {
+    notiId: "TOGGLE_SHELLY_PLUG",
+    notiPayload: [
+      {
+        payloadValue: '', 
+        notiMqttCmd: ["Command 3"]
+      },
+    ],
+  },
 ];
 var notiMqttCommands = [
   {
@@ -146,6 +159,12 @@ var notiMqttCommands = [
     commandId: "Command 2",
     mqttTopic: "myhome/kitchen/temperature",
     mqttMsgPayload: ''
+  },
+  {
+    commandId: "Command 3",
+    mqttTopic: "shellies/plug/relay/0/command",
+    stringifyPayload: false,
+    mqttMsgPayload: 'toogle'
   },
 ];
 ```


### PR DESCRIPTION
Hi,

i do have problems controlling my Shelly plugs with the module cause of the "JSON.stringify" happening before the payload will be send as MQTT message.

With the changes in this pull request the stringification can be controlled with a general configuration option "stringifyPayload" which can be overriden by notifications in their configuration in notiMqttCommands if needed.

The default behavior stays the same.